### PR TITLE
Load the bridge module instead of test_module

### DIFF
--- a/cm-entrypoint.yaml
+++ b/cm-entrypoint.yaml
@@ -65,5 +65,6 @@ data:
     chroot "${ROOT_MOUNT_DIR}" apt-get install -y nano
 
     echo "Loading Kernel modules"
-    chroot "${ROOT_MOUNT_DIR}" modprobe test_module
+    # Load the bridge kernel module as an example
+    chroot "${ROOT_MOUNT_DIR}" modprobe bridge
 ...

--- a/verify-init.sh
+++ b/verify-init.sh
@@ -33,7 +33,7 @@ else
     exit 2
 fi
 
-if gcloud compute ssh "$NODE_NAME" --zone "$ZONE" --command "lsmod | grep test_module" > /dev/null 2>&1; then
+if gcloud compute ssh "$NODE_NAME" --zone "$ZONE" --command "lsmod | grep bridge" > /dev/null 2>&1; then
     echo "Kernel modules loaded successfully on $NODE_NAME ($ZONE)"
 else
     echo "Kernel modules not loaded successfully on $NODE_NAME ($ZONE)"


### PR DESCRIPTION
The kernel that ships with Ubuntu GKE nodes doesn't include the test_module anymore, so the provisioning and verification scripts fail. Switch to a module that is currently there, and less likely to be disabled in the future.