### PR TITLE
Fix missing project template

### DIFF
--- a/time-sync-example/gce/clock-error-metric.json
+++ b/time-sync-example/gce/clock-error-metric.json
@@ -1,7 +1,7 @@
 {
     "name": "phc-clock-max-error-gce",
     "description": "Maximum error of the VM clock from the host clock exposed by ptp_kvm",
-    "filter": "logName=\"projects/clock-accuracy/logs/chrony_tracking_receiver\"",
+    "filter": "logName=\"projects/PROJECT_ID/logs/chrony_tracking_receiver\"",
     "metricDescriptor": {
                         "metricKind": "DELTA",
                         "valueType": "DISTRIBUTION",

--- a/time-sync-example/gce/time-sync-logging-dashboard.sh
+++ b/time-sync-example/gce/time-sync-logging-dashboard.sh
@@ -21,5 +21,8 @@ gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
     --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
     --role="roles/logging.logWriter"
 
-gcloud logging metrics create phc-clock-max-error-gce --config-from-file=clock-error-metric.json
-gcloud monitoring dashboards create --config-from-file=metric-dashboard.json
+cp clock-error-metric.json /tmp/clock-error-metric.json
+sed -i "s/PROJECT_ID/${PROJECT_ID}/" /tmp/clock-error-metric.json
+
+gcloud logging metrics create --project "${PROJECT_ID}" phc-clock-max-error-gce --config-from-file=/tmp/clock-error-metric.json
+gcloud monitoring dashboards create --project "${PROJECT_ID}" --config-from-file=metric-dashboard.json


### PR DESCRIPTION
Some of the sample GCE scripts were missing proper project-ID specification, resulting in missing dashboard. This PR fixes the missing argument passing.